### PR TITLE
update to .net 9.0

### DIFF
--- a/Feirapp-Backend/Feirapp.API/Feirapp.API.csproj
+++ b/Feirapp-Backend/Feirapp.API/Feirapp.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/Feirapp-Backend/Feirapp.Domain/Feirapp.Domain.csproj
+++ b/Feirapp-Backend/Feirapp.Domain/Feirapp.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Feirapp-Backend/Feirapp.Entities/Feirapp.Entities.csproj
+++ b/Feirapp-Backend/Feirapp.Entities/Feirapp.Entities.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Feirapp-Backend/Feirapp.Infrastructure/Feirapp.Infrastructure.csproj
+++ b/Feirapp-Backend/Feirapp.Infrastructure/Feirapp.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Feirapp-Backend/Feirapp.Tests/Feirapp.Tests.csproj
+++ b/Feirapp-Backend/Feirapp.Tests/Feirapp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>        
         <IsPackable>false</IsPackable>        
     </PropertyGroup>


### PR DESCRIPTION
This pull request updates the target framework for all projects in the `Feirapp-Backend` solution from `.NET 8.0` to `.NET 9.0`. This ensures that the projects leverage the latest features and improvements provided by the updated framework.

Framework upgrade:

* [`Feirapp.API.csproj`](diffhunk://#diff-f48de2c2fbf8b624401944d460fdb77c5d340a2dec57ba633e7f788d4b07f552L4-R4): Changed `<TargetFramework>` from `net8.0` to `net9.0` to align with the latest framework version.
* [`Feirapp.Domain.csproj`](diffhunk://#diff-114ac220128af3dc39638568e617cd26c295e0f50d2d5e5e71dc248ba3220c46L4-R4): Updated `<TargetFramework>` from `net8.0` to `net9.0` for compatibility with the new framework.
* [`Feirapp.Entities.csproj`](diffhunk://#diff-d6cfa0bbc33a70914f1e4ceb475e29dfc98ebe21bf9fb35dd7f7822f53233156L4-R4): Migrated `<TargetFramework>` from `net8.0` to `net9.0` to utilize new features.
* [`Feirapp.Infrastructure.csproj`](diffhunk://#diff-27fc2ff6cc9287d40cfb7b8ba1b1c66ca0356fd12a0913f420b6f884b16c64edL4-R4): Adjusted `<TargetFramework>` from `net8.0` to `net9.0` for consistency across the solution.
* [`Feirapp.Tests.csproj`](diffhunk://#diff-eceb30e6b72ef76e7211a54f66cf803c70452eef3e1c316448d3956311005c45L4-R4): Updated `<TargetFramework>` from `net8.0` to `net9.0` to ensure testing aligns with the main application framework.